### PR TITLE
Fix condition when onlyaggregate is not set in aggregate run script

### DIFF
--- a/aggregate/run.sh
+++ b/aggregate/run.sh
@@ -157,7 +157,7 @@ while [ "$di" != "$end_on" ]; do
 
         if [ ! -f $cur_file_gz ]; then
 
-            if [ "$onlyaggregate" -eq "1" ]; then
+            if [ -n "$onlyaggregate" ]; then
                 echo "File ${cur_file_gz} not found, --onlyaggregate mode is turned on, skipping the date"
                 skip_date=1
                 break


### PR DESCRIPTION
When onlyaggregate is not set in aggregate run script, then -eq operator will fail, because it expects a number, not an empty string. The change of the condition to check whether the onlyaggregate variable is set will help.